### PR TITLE
actualice CartaMonstruo con boosts temporales y modo defensa

### DIFF
--- a/src/CartaMonstruo.java
+++ b/src/CartaMonstruo.java
@@ -1,12 +1,12 @@
 public class CartaMonstruo extends Carta {
- 
+
     private byte nivelCarta;
     private short atk;
     private short def;
     private short boostAtk;
     private short boostDef;
     private boolean puedeAtacar;
-    private boolean enModoDefensa;   
+    private boolean enModoDefensa;
 
     public CartaMonstruo(String nombre, byte nivelCarta, short atk, short def) {
         super(nombre);
@@ -18,23 +18,23 @@ public class CartaMonstruo extends Carta {
         this.puedeAtacar = false;
         this.enModoDefensa = false;
     }
- 
+
     public int getnivelCarta() {
         return nivelCarta;
     }
- 
+
     public int getAtk() {
         return atk + boostAtk;
     }
- 
+
     public int getDef() {
         return def + boostDef;
     }
- 
+
     public boolean puedeAtacar() {
         return puedeAtacar;
     }
- 
+
     public void setPuedeAtacar(boolean puedeAtacar) {
         this.puedeAtacar = puedeAtacar;
     }
@@ -44,13 +44,10 @@ public class CartaMonstruo extends Carta {
     }
 
     public void cambiarPosicion() {
-        // Si era true (Defensa), pasa a false (Ataque). Si era false, pasa a true.
         this.enModoDefensa = !this.enModoDefensa;
-        // Es un "if-else" rapido: si 'enModoDefensa' es true, asigna "DEFENSA", de lo contrario asigna "ATAQUE".
         String modo = enModoDefensa ? "DEFENSA" : "ATAQUE";
         System.out.println(">>> " + getNombre() + " cambió a modo " + modo + ".");
     }
-
 
     public void aplicarBoostAtk(short incremento) {
         boostAtk = incremento;
@@ -90,10 +87,10 @@ public class CartaMonstruo extends Carta {
 
     @Override
     public String toString() {
-        String modo = enModoDefensa ? "[DEFENSA]" : "[ATAQUE]";
-        return modo + " " + getNombre() 
-            + " | nivel: " + nivelCarta 
-            + " | ATK: " + getAtk() 
-            + " | DEF: " + getDef();
+        String modo = enModoDefensa ? "[DEF]" : "[ATK]";
+        return modo + " " + getNombre()
+            + " Lv" + nivelCarta
+            + " ATK:" + getAtk()
+            + " DEF:" + getDef();
     }
 }


### PR DESCRIPTION
se actuializo CartaMonstruo con boosts temporales y modo defensa

- boostAtk y boostDef almacenan incrementos temporales de stats
- getAtk() y getDef() retornan valor base + boost
- cambiarPosicion() alterna entre modo ATK y DEF con log en consola
- aplicarBoostAtk/Def() asignan el boost del turno
- decrementarMejora() limpia los boosts al inicio del turno del dueño
- resetTurno() habilita el ataque del monstruo para el nuevo turno