### PR TITLE
implemente carta trampas de daño directo a LP

### DIFF
--- a/src/EspejoDeAlmas.java
+++ b/src/EspejoDeAlmas.java
@@ -1,0 +1,29 @@
+/**
+ * Trampa: Espejo de Almas
+ * Copia el ATK del monstruo más fuerte del oponente e inflige ese valor como daño de LP.
+ * Condición: el oponente tiene monstruos en campo.
+ */
+public class EspejoDeAlmas extends CartaTrampa {
+
+    public EspejoDeAlmas() {
+        super("Espejo de Almas", "Inflige daño igual al ATK del monstruo más fuerte del oponente.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return !ctx.getOponente().getCampo().isEmpty();
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        Jugador oponente = ctx.getOponente();
+        if (oponente.getCampo().isEmpty()) return;
+        int maxAtk = 0;
+        for (CartaMonstruo m : oponente.getCampo()) {
+            if (m.getAtk() > maxAtk) maxAtk = m.getAtk();
+        }
+        // inflige la mitad del ATK para no ser demasiado poderosa
+        int danio = maxAtk / 2;
+        oponente.recibirDanio(danio);
+    }
+}

--- a/src/ReflejoMagico.java
+++ b/src/ReflejoMagico.java
@@ -1,0 +1,22 @@
+/**
+ * Trampa: Reflejo Mágico
+ * Inflige 500 LP de daño al oponente. Se activa en respuesta a una carta mágica.
+ * Condición: siempre se puede activar (el jugador elige cuándo usarla en su turno de trampas).
+ */
+public class ReflejoMagico extends CartaTrampa {
+
+    public ReflejoMagico() {
+        super("Reflejo Mágico", "Inflige 500 LP de daño directo al oponente.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return true;
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        Jugador oponente = ctx.getOponente();
+        oponente.recibirDanio(500);
+    }
+}

--- a/src/TormentaDeTruenos.java
+++ b/src/TormentaDeTruenos.java
@@ -1,0 +1,24 @@
+/**
+ * Trampa: Tormenta de Truenos
+ * Inflige 300 LP de daño al oponente por cada monstruo que tenga en campo.
+ */
+public class TormentaDeTruenos extends CartaTrampa {
+
+    public TormentaDeTruenos() {
+        super("Tormenta de Truenos", "Inflige 300 de daño al oponente por cada monstruo en su campo.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return !ctx.getOponente().getCampo().isEmpty();
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        Jugador oponente = ctx.getOponente();
+        int danio = 300 * oponente.getCampo().size();
+        if (danio > 0) {
+            oponente.recibirDanio(danio);
+        }
+    }
+}


### PR DESCRIPTION
se implemento trampas de daño directo a LP

- ReflejoMagico: inflige 500 LP de daño, siempre activable
- TormentaDeTruenos: 300 LP por cada monstruo del oponente en campo
- EspejoDeAlmas: daño igual a la mitad del ATK del monstruo más fuerte del oponente
Todas extienden CartaTrampa e implementan puedoActivarme() y activar()