### PR TITLE
implemente trampas de control y utilidad

### DIFF
--- a/src/DestinoInexorable.java
+++ b/src/DestinoInexorable.java
@@ -1,0 +1,23 @@
+/**
+ * Trampa: Destino Inexorable
+ * El oponente pierde 800 LP y no puede jugar cartas en su próximo turno.
+ * Se puede activar en cualquier momento.
+ */
+public class DestinoInexorable extends CartaTrampa {
+
+    public DestinoInexorable() {
+        super("Destino Inexorable", "El oponente pierde 800 LP y no puede jugar cartas el próximo turno.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return true;
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        Jugador oponente = ctx.getOponente();
+        oponente.recibirDanio(800);
+        oponente.bloquearJugarCartaProximoTurno();
+    }
+}

--- a/src/EscudoSagrado.java
+++ b/src/EscudoSagrado.java
@@ -1,0 +1,23 @@
+/**
+ * Trampa: Escudo Sagrado
+ * Da +1000 DEF a todos los monstruos propios en campo este turno.
+ * Condición: el jugador activo tiene monstruos en campo.
+ */
+public class EscudoSagrado extends CartaTrampa {
+
+    public EscudoSagrado() {
+        super("Escudo Sagrado", "+1000 DEF a todos tus monstruos en campo este turno.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return !ctx.getJugadorActivo().getCampo().isEmpty();
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        for (CartaMonstruo m : ctx.getJugadorActivo().getCampo()) {
+            m.aplicarBoostDef((short) 1000);
+        }
+    }
+}

--- a/src/RenacerDelFenix.java
+++ b/src/RenacerDelFenix.java
@@ -1,0 +1,22 @@
+/**
+ * Trampa: Renacer del Fénix
+ * Otorga al jugador activo 1500 LP extra.
+ * Se puede activar en cualquier momento.
+ */
+public class RenacerDelFenix extends CartaTrampa {
+
+    public RenacerDelFenix() {
+        super("Renacer del Fénix", "Recupera 1500 LP cuando tus puntos de vida bajen de 3000.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return ctx.getJugadorActivo().getLp() < 3000;
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        Jugador j = ctx.getJugadorActivo();
+        j.setLp(j.getLp() + 1500);
+    }
+}

--- a/src/RoboForzado.java
+++ b/src/RoboForzado.java
@@ -1,0 +1,25 @@
+/**
+ * Trampa: Robo Forzado
+ * Fuerza al oponente a descartar la primera carta de su mano.
+ * Condición: el oponente tiene al menos una carta en la mano.
+ */
+public class RoboForzado extends CartaTrampa {
+
+    public RoboForzado() {
+        super("Robo Forzado", "El oponente descarta 1 carta de su mano.");
+    }
+
+    @Override
+    public boolean puedoActivarme(Contexto ctx) {
+        return !ctx.getOponente().getMano().isEmpty();
+    }
+
+    @Override
+    public void activar(Contexto ctx) {
+        Jugador oponente = ctx.getOponente();
+        if (!oponente.getMano().isEmpty()) {
+            Carta descartada = oponente.getMano().remove(0);
+            System.out.println(">>> " + oponente.getNombre() + " descartó: " + descartada.getNombre());
+        }
+    }
+}


### PR DESCRIPTION
se implemento trampas de control y utilidad

- RenacerDelFenix: recupera 1500 LP (solo si el jugador tiene menos de 3000 LP)
- DestinoInexorable: 800 LP de daño + bloquea al oponente de jugar cartas su próximo turno
- RoboForzado: el oponente descarta la primera carta de su mano
- EscudoSagrado: +1000 DEF a todos los monstruos propios en campo este turno